### PR TITLE
Linux makefile fixes

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -54,9 +54,9 @@ endif
 SHLIBEXT=so
 SHLIBCFLAGS=
 ifeq "$(CFG)" "release"
-	SHLIBLDFLAGS="-shared -Wl,-Map,$@_map.txt"
+	SHLIBLDFLAGS="-shared -Wl,-Map,$@_map.txt -Wl,--no-undefined"
 else
-	SHLIBLDFLAGS="-shared -gdwarf-2 -g2 -Wl,-Map,$@_map.txt"
+	SHLIBLDFLAGS="-shared -gdwarf-2 -g2 -Wl,-Map,$@_map.txt -Wl,--no-undefined"
 endif
 
 AR=ar

--- a/linux/Makefile.hl_cdll
+++ b/linux/Makefile.hl_cdll
@@ -113,11 +113,13 @@ DLL_OBJS = \
 	$(HL1_SERVER_OBJ_DIR)/handgrenade.o \
 	$(HL1_SERVER_OBJ_DIR)/hornetgun.o \
 	$(HL1_SERVER_OBJ_DIR)/mp5.o \
+	$(HL1_SERVER_OBJ_DIR)/physgun.o \
 	$(HL1_SERVER_OBJ_DIR)/python.o \
 	$(HL1_SERVER_OBJ_DIR)/rpg.o \
 	$(HL1_SERVER_OBJ_DIR)/satchel.o \
 	$(HL1_SERVER_OBJ_DIR)/shotgun.o \
 	$(HL1_SERVER_OBJ_DIR)/squeakgrenade.o \
+	$(HL1_SERVER_OBJ_DIR)/toolgun.o \
 	$(HL1_SERVER_OBJ_DIR)/tripmine.o \
 	$(HL1_SERVER_OBJ_DIR)/weapons_shared.o \
 

--- a/linux/Makefile.hldll
+++ b/linux/Makefile.hldll
@@ -106,9 +106,11 @@ HLDLL_OBJS = \
 	$(HLDLL_OBJ_DIR)/gargantua.o \
 	$(HLDLL_OBJ_DIR)/gauss.o \
 	$(HLDLL_OBJ_DIR)/genericmonster.o \
+	$(HLDLL_OBJ_DIR)/geneworm.o \
 	$(HLDLL_OBJ_DIR)/ggrenade.o \
 	$(HLDLL_OBJ_DIR)/glock.o \
 	$(HLDLL_OBJ_DIR)/gman.o \
+	$(HLDLL_OBJ_DIR)/gonome.o \
 	$(HLDLL_OBJ_DIR)/h_ai.o \
 	$(HLDLL_OBJ_DIR)/h_battery.o \
 	$(HLDLL_OBJ_DIR)/h_cine.o \

--- a/linux/Makefile.hldll
+++ b/linux/Makefile.hldll
@@ -151,6 +151,7 @@ HLDLL_OBJS = \
 	$(HLDLL_OBJ_DIR)/otis.o \
 	$(HLDLL_OBJ_DIR)/pathcorner.o \
 	$(HLDLL_OBJ_DIR)/penguin_grenade.o \
+	$(HLDLL_OBJ_DIR)/physgun.o \
 	$(HLDLL_OBJ_DIR)/pitdrone.o \
 	$(HLDLL_OBJ_DIR)/pitworm_up.o \
 	$(HLDLL_OBJ_DIR)/plane.o \
@@ -181,6 +182,7 @@ HLDLL_OBJS = \
 	$(HLDLL_OBJ_DIR)/singleplay_gamerules.o \
 	$(HLDLL_OBJ_DIR)/tempmonster.o \
 	$(HLDLL_OBJ_DIR)/tentacle.o \
+	$(HLDLL_OBJ_DIR)/toolgun.o \
 	$(HLDLL_OBJ_DIR)/triggers.o \
 	$(HLDLL_OBJ_DIR)/tripmine.o \
 	$(HLDLL_OBJ_DIR)/turret.o \


### PR DESCRIPTION
* adds -Wl,--no-undefined flag to the shared object link flags
* adds missing gonome and geneworm entities
* adds missing toolgun and physgun entities

